### PR TITLE
chore: update keybindings and configs for ghostty, nvim, and tmux

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,6 +1,6 @@
 font-size = 12
 
-theme = tokyonight_moon
+theme = TokyoNight Moon
 
 link-url = true
 

--- a/.config/nvim/lua/nem/core/keymaps.lua
+++ b/.config/nvim/lua/nem/core/keymaps.lua
@@ -2,7 +2,7 @@ vim.g.mapleader = " "
 
 local keymap = vim.keymap
 
-keymap.set("n", "<leader>s", ":w<CR>", { desc = "Save current buffer" })
+keymap.set("n", "<leader>w", ":w<CR>", { desc = "Save current buffer" })
 keymap.set("n", "<leader>q", ":q<CR>", { desc = "Quit current buffer" })
 keymap.set("n", "<leader>sv", "<C-w>v", { desc = "Split window vertically" })
 keymap.set("n", "<leader>sh", "<C-w>s", { desc = "Split window horizontally" })

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -32,16 +32,19 @@ unbind-key C-z
 bind | split-window -h
 bind - split-window -v
 bind q kill-pane
-bind C-h select-pane -L
-bind C-j select-pane -D
-bind C-k select-pane -U
-bind C-l select-pane -R
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
 
-# Resize panes with prefix + hjkl
-bind -r h resize-pane -L 2
-bind -r j resize-pane -D 2
-bind -r k resize-pane -U 2
-bind -r l resize-pane -R 2
+# Resize panes with prefix + H/J/K/L
+bind -r H resize-pane -L 2
+bind -r J resize-pane -D 2
+bind -r K resize-pane -U 2
+bind -r L resize-pane -R 2
+
+# Toggle zoom for the current pane
+bind -r m resize-pane -Z
 
 # Reload tmux configuration
 bind r source-file ~/.tmux.conf \; display-message "Config reloaded"


### PR DESCRIPTION
## Summary
- Fix ghostty theme name casing (`tokyonight_moon` → `TokyoNight Moon`)
- Remap nvim save key from `<leader>s` to `<leader>w`
- Switch tmux pane navigation from `C-hjkl` to plain `hjkl`, resize to uppercase `HJKL`, and add zoom toggle with `prefix + m`

## Test plan
- [ ] Ghostty applies TokyoNight Moon theme correctly on launch
- [ ] Neovim `<leader>w` saves the current buffer
- [ ] Tmux pane navigation works with `prefix + hjkl`
- [ ] Tmux pane resize works with `prefix + HJKL`
- [ ] Tmux zoom toggle works with `prefix + m`